### PR TITLE
add keybonding for linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,12 +205,14 @@
         "command": "extension.fileheader",
         "key": "ctrl+alt+i",
         "mac": "ctrl+cmd+i",
+        "linux": "ctrl+meta+i",
         "when": "editorTextFocus"
       },
       {
         "command": "extension.cursorTip",
         "key": "ctrl+alt+t",
         "mac": "ctrl+cmd+t",
+        "linux": "ctrl+meta+t",
         "when": "editorTextFocus"
       }
     ]


### PR DESCRIPTION
linux下使用 ctrl+meta+t 和 ctrl+meta+i;meta就是mac的cmd,windows的win键.
原来的ctrl+alt+t在linux某些桌面环境中是全局调出终端的快捷键,建议修改.