### PR TITLE
fix: functionParamsShape配置'no type'时，不会添加functionParamAddStr的错误

### DIFF
--- a/src/languageOutPut/languageOutput.js
+++ b/src/languageOutPut/languageOutput.js
@@ -149,27 +149,31 @@ class FunctionTplStr {
   // 拼接type和param参数
   getTypeVal (item = {}) {
     const typeVal = this.getTodoType(item)
+
+    // type 和 param 都不存在
+    if (item.type === undefined && item.param === undefined) {
+      return typeVal
+    }
+
     // 配置不要类型捕获
+    let res = ''
     if (this.config.configObj.functionParamsShape === 'no type') {
       // return 没有param
       if (item.param === undefined) {
         return ''
       }
-      return `${item.param}`
-    }
-    // 默认值没有匹配到param
-    if (item.type === undefined && item.param === undefined) {
-      return typeVal
-    }
-    const typeParamOrder = this.config.configObj.typeParamOrder
-    let res = ''
-    if (typeParamOrder === 'type param') {
-      res = `${typeVal} ${item.param}`
-    } else if (typeParamOrder === 'param type') {
-      res = `${item.param} ${typeVal}`
-    } else if (typeParamOrder === 'param') {
       res = `${item.param}`
+    } else {
+      const typeParamOrder = this.config.configObj.typeParamOrder
+      if (typeParamOrder === 'type param') {
+        res = `${typeVal} ${item.param}`
+      } else if (typeParamOrder === 'param type') {
+        res = `${item.param} ${typeVal}`
+      } else if (typeParamOrder === 'param') {
+        res = `${item.param}`
+      }
     }
+
     // 在type param 后面增加字符串 可能是冒号，方便输入参数描述
     const functionParamAddStr = this.config.configObj.functionParamAddStr
     if (functionParamAddStr) {


### PR DESCRIPTION
当 `functionParamsShape`配置'no type'时，没有使用 `functionParamAddStr` 配置

测试配置：
```
        "functionParamAddStr": " ", // 在 type param 后面增加字符串 - 空格，方便输入参数描述
        "functionParamsShape": "no type", // 函数参数不需要类型
```
新旧效果对比如下：

![image](https://user-images.githubusercontent.com/4076317/218093018-dca49dec-7881-4680-a7b4-bf0c3ee8d7f1.png)

![image](https://user-images.githubusercontent.com/4076317/218093060-f8b0168f-f4f8-47e1-aadc-2ef58430c79f.png)
